### PR TITLE
Provide SPDX license identifier for packages

### DIFF
--- a/src/NGettext.PluralCompile/NGettext.PluralCompile.csproj
+++ b/src/NGettext.PluralCompile/NGettext.PluralCompile.csproj
@@ -15,6 +15,7 @@
     <PackageTags>ngettext;gettext;internationalization;localization;i18n;l10n;translate</PackageTags>
     <PackageProjectUrl>https://github.com/neris/NGettext</PackageProjectUrl>
     <PackageLicense>https://raw.githubusercontent.com/neris/NGettext/master/LICENSE</PackageLicense>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/neris/NGettext</RepositoryUrl>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>

--- a/src/NGettext/NGettext.csproj
+++ b/src/NGettext/NGettext.csproj
@@ -15,6 +15,7 @@
     <PackageTags>ngettext;gettext;internationalization;localization;i18n;l10n;translate</PackageTags>
     <PackageProjectUrl>https://github.com/neris/NGettext</PackageProjectUrl>
     <PackageLicense>https://raw.githubusercontent.com/neris/NGettext/master/LICENSE</PackageLicense>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>git://github.com/neris/NGettext</RepositoryUrl>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>


### PR DESCRIPTION
This change adds the SPDX license identifier to the generated NuGet packages by adding the appropriate [PackageLicenseExpression](https://docs.microsoft.com/en-us/dotnet/standard/library-guidance/nuget) tag.

**Why?** Companies use the license information provided by package managers to ensure compliance across large projects. Providing an SPDX license identifier makes it simpler for people to work with automated tools like [LicenseFinder](https://github.com/pivotal/LicenseFinder) or GitLab's license scanning feature.