### PR TITLE
Handle translation duplicates 

### DIFF
--- a/src/NGettext/Loaders/MoLoader.cs
+++ b/src/NGettext/Loaders/MoLoader.cs
@@ -291,7 +291,10 @@ namespace NGettext.Loaders
 		{
 			foreach (var translation in parsedMoFile.Translations)
 			{
-				catalog.Translations.Add(translation.Key, translation.Value);
+				if (!catalog.Translations.ContainsKey(translation.Key))
+					catalog.Translations.Add(translation.Key, translation.Value);
+				else
+					Trace.WriteLine(String.Format("Duplicate Translation Key: \"{0}\".", translation.Key), "NGettext");
 			}
 
 			if (parsedMoFile.Headers.ContainsKey("Plural-Forms"))


### PR DESCRIPTION
The current implementation throws an ArgumentException if a translation string already exists. Thus, multiple moFiles with sometimes identical translations can not be merged. This PR changes this behavior by rather writing a warning message to the log.